### PR TITLE
mitigation: ensure constant uncx flat fee M-3

### DIFF
--- a/src/PartyTokenLauncher.sol
+++ b/src/PartyTokenLauncher.sol
@@ -432,8 +432,8 @@ contract PartyTokenLauncher is Ownable, IERC721Receiver {
                 tickUpper: MAX_TICK,
                 amount0Desired: amount0,
                 amount1Desired: amount1,
-                amount0Min: 0,
-                amount1Min: 0,
+                amount0Min: amount0 * 9999 / 10_000,
+                amount1Min: amount1 * 9999 / 10_000,
                 recipient: address(this),
                 deadline: block.timestamp
             })


### PR DESCRIPTION
In the case that the UNCX flat fee changes, the proportion of token and eth added will change such that not all available assets will be added to the full range position. This change results in a revert in that case. Contributors will withdraw instead of being subject to the changed fees.